### PR TITLE
chore: add monorepo vercel support

### DIFF
--- a/packages/build-hooks/package.json
+++ b/packages/build-hooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flexn/build-hooks",
-    "version": "0.30.0",
+    "version": "0.30.0-feat.0",
     "description": "Flexn Build Hooks",
     "main": "lib/index",
     "types": "lib/index",

--- a/packages/build-hooks/src/deploy/iosFirebase.ts
+++ b/packages/build-hooks/src/deploy/iosFirebase.ts
@@ -14,9 +14,10 @@ const iosFirebaseDeploy = (config: any) =>
         const token = config.files.workspace.project?.configPrivate?.firebase?.token;
 
         const firebaseId = Common.getConfigProp(config, config.platform, 'firebaseId');
+        const firebaseGroups = Common.getConfigProp(config, config.platform, 'firebaseGroups');
         const title = Common.getConfigProp(config, config.platform, 'title');
 
-        const args = `firebase appdistribution:distribute ${ipaPath} --app ${firebaseId} --groups "RS" --token="${token}"`;
+        const args = `firebase appdistribution:distribute ${ipaPath} --app ${firebaseId} --groups "${firebaseGroups}" --token="${token}"`;
 
         Exec.executeAsync(config, args, {
             shell: true,

--- a/packages/build-hooks/src/deploy/vercel.ts
+++ b/packages/build-hooks/src/deploy/vercel.ts
@@ -13,7 +13,7 @@ const vercelDeploy = async (config: any) => {
 
     // remove .vercel/project.json othwerise it will deploy to the last location
     try {
-        fs.unlinkSync(`${process.cwd()}/platformBuilds/${config.runtime.appId}_${platform}/.vercel/project.json`);
+        fs.unlinkSync(`${process.cwd()}/../../.vercel/project.json`);
     } catch (_) {
         // it's deleted most likely
     }
@@ -25,7 +25,7 @@ const vercelDeploy = async (config: any) => {
 
         await Exec.executeAsync(
             config,
-            `npx vercel ./platformBuilds/${config.runtime.appId}_${platform}/output --token=${
+            `npx vercel ../../. --token=${
                 process.env.VERCEL_TOKEN || token
             } --name=${vercelProjectName} --scope=flexn -f --confirm --prod`,
             {


### PR DESCRIPTION
- The iosFirebase should be applied in all instanced
- The vercel bit should be applied only when use case is monorepo - this needs more work